### PR TITLE
Mirror Battles fully functional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ tools/swav2swar.exe
 
 *.gbapal
 *.4bpp
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,8 @@
         "item.h": "c",
         "weather_numbers.h": "c",
         "ability.h": "c",
-        "bag.h": "c"
+        "bag.h": "c",
+        "pokemon.h": "c",
+        "battle.h": "c"
     }
 }

--- a/armips/include/constants.s
+++ b/armips/include/constants.s
@@ -568,6 +568,7 @@
 .equ F_ROAMING_MON, (1 << 11)
 .equ F_SAFARI_ZONE, (1 << 12)
 .equ F_CATCHING_DEMO, (1 << 13)
+.equ F_MIRROR_BATTLE, (1 << 14)
 
 // battle types
 

--- a/include/config.h
+++ b/include/config.h
@@ -128,12 +128,13 @@
 
 // COPY_ENEMY_PARTY will make player party be the enemy trainers
 // comment out the line below to disable it
-// #define COPY_ENEMY_PARTY
+#define COPY_ENEMY_PARTY
 
 // SAVE_OWN_PARTY will make player party be saved if copying enemy party
 // comment out the line below to disable it
 // only used if copying enemy party
-// #define SAVE_OWN_PARTY
+#define SAVE_OWN_PARTY
+
 // IMPLEMENT_REUSABLE_REPELS defines whether or not a prompt to use another repel automatically appears upon the previous repel being used up
 #define IMPLEMENT_REUSABLE_REPELS
 

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -744,6 +744,9 @@ enum
 #define TRAINER_DATA_EXTRA_TYPE_PP_COUNTS 0x100
 #define TRAINER_DATA_EXTRA_TYPE_NICKNAME 0x200
 
+/**Trainer AI (using for Mirror Battles) **/
+#define F_MIRROR_BATTLE (1 << 14)
+
 // kinda weird, specifically tracked in the RAM
 typedef struct WildEncounterWork
 {

--- a/src/battle/battle_pokemon.c
+++ b/src/battle/battle_pokemon.c
@@ -901,7 +901,39 @@ void BattleEndRevertFormChange(struct BattleSystem *bw)
         for (j = 0; j < 11; j++)
             gIllusionStruct.illusionNameBuf[SanitizeClientForTeamAccess(bw, i)][j] = 0;
     }
+    #if defined(COPY_ENEMY_PARTY) && defined(SAVE_OWN_PARTY)
+    // Is it a mirror battle ?
+    if (bw->trainers[1].aibit & F_MIRROR_BATTLE) {
+        PokeParty_Init(bw->trainerParty[0], 6);        
+        for (i = 0; i < BattleWorkPokeCountGet(bw, 2); i++)
+        {
+            pp = BattleWorkPokemonParamGet(bw, 2, i);
+            monsno = GetMonData(pp, MON_DATA_SPECIES, NULL);
+            form = GetMonData(pp, MON_DATA_FORM, NULL);
 
+            if (RevertFormChange(pp, monsno, form))
+            {
+                ResetPartyPokemonAbility(pp);
+            }
+            RecalcPartyPokemonStats(pp); // always recalc stats at the end of each battle
+            PokeParty_Add(bw->trainerParty[0], pp);
+        }
+    } else {
+        for (i = 0; i < BattleWorkPokeCountGet(bw, 0); i++)
+        {
+            pp = BattleWorkPokemonParamGet(bw, 0, i);
+            monsno = GetMonData(pp, MON_DATA_SPECIES, NULL);
+            form = GetMonData(pp, MON_DATA_FORM, NULL);
+
+            if (RevertFormChange(pp, monsno, form))
+            {
+                ResetPartyPokemonAbility(pp);
+            }
+            RecalcPartyPokemonStats(pp); // always recalc stats at the end of each battle
+        }
+    }
+    
+    #else
     for (i = 0; i < BattleWorkPokeCountGet(bw, 0); i++)
     {
         pp = BattleWorkPokemonParamGet(bw, 0, i);
@@ -914,6 +946,7 @@ void BattleEndRevertFormChange(struct BattleSystem *bw)
         }
         RecalcPartyPokemonStats(pp); // always recalc stats at the end of each battle
     }
+    #endif
 
 #ifdef RESTORE_ITEMS_AT_BATTLE_END
     // grab newItems array for use later

--- a/src/field/enemy_party.c
+++ b/src/field/enemy_party.c
@@ -130,17 +130,21 @@ void MakeTrainerPokemonParty(struct BATTLE_PARAM *bp, int num, int heapID)
     }    
     #endif
 
-    PokeParty_Init(bp->poke_party[num], 6);
+    PokeParty_Init(bp->poke_party[num], 6);    
     #ifdef COPY_ENEMY_PARTY
-    #ifdef SAVE_OWN_PARTY
-    for (int i = 0; i < bp->poke_party[0]->count; i++) {
-        struct BoxPokemon mon = bp->poke_party[0]->members[i].box;
-        PCStorage_PlaceMonInFirstEmptySlotInAnyBox(SaveArray_PCStorage_Get(gFieldSysPtr->savedata), &mon);
-    }
-    #endif
-    PokeParty_Init(bp->poke_party[0], 6);
-    #endif
-
+    // Is it a mirror battle ?
+    if (bp->trainer_data[num].aibit & F_MIRROR_BATTLE) {
+        #ifdef SAVE_OWN_PARTY
+        PokeParty_Init(bp->poke_party[2], 6);
+        for (i = 0; i < bp->poke_party[0]->count; i++)
+        {
+            struct PartyPokemon pp = bp->poke_party[0]->members[i];
+            PokeParty_Add(bp->poke_party[2], &pp);
+        }
+        #endif
+        PokeParty_Init(bp->poke_party[0], 6);
+    }    
+            #endif
     buf = (u8 *)sys_AllocMemory(heapID, sizeof(struct FULL_TRAINER_MON_DATA_STRUCTURE) * 6);
 
     TT_TrainerPokeDataGet(bp->trainer_id[num], buf);
@@ -383,7 +387,7 @@ void MakeTrainerPokemonParty(struct BATTLE_PARAM *bp, int num, int heapID)
                     nickname[j] = buf[offset] | (buf[offset+1] << 8);
                     offset += 2;
                 }
-            }
+            }            
         }
 
         // ball seal field


### PR DESCRIPTION
Vastly improves the mirror battle handling AND saves party

To use simply add the AI flag to trainer `F_MIRROR_BATTLE`

### IMPORTANT

A big assumption here is that they will ONLY be used for singles, the trainer party is saved to trainer 3 which normally would be the players "partner".
POTENTIALLY it might work in doubles but it needs testing